### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/slice/iter.rs
+++ b/src/slice/iter.rs
@@ -563,11 +563,11 @@ group!(Windows => &'a BitSlice<T, O> {
 			self.slice = Default::default();
 			return None;
 		}
-		unsafe {
-			let out = self.slice.get_unchecked(.. self.width);
-			self.slice = self.slice.get_unchecked(1 ..);
+		
+			let out = unsafe { self.slice.get_unchecked(.. self.width) };
+			self.slice = unsafe { self.slice.get_unchecked(1 ..) };
 			Some(out)
-		}
+		
 	}
 
 	fn nth(&mut self, n: usize) -> Option<Self::Item> {
@@ -576,11 +576,11 @@ group!(Windows => &'a BitSlice<T, O> {
 			self.slice = Default::default();
 			return None;
 		}
-		unsafe {
-			let out = self.slice.get_unchecked(n .. end);
-			self.slice = self.slice.get_unchecked(n + 1 ..);
+		
+			let out = unsafe { self.slice.get_unchecked(n .. end) };
+			self.slice = unsafe { self.slice.get_unchecked(n + 1 ..) };
 			Some(out)
-		}
+		
 	}
 
 	fn next_back(&mut self) -> Option<Self::Item> {
@@ -589,11 +589,11 @@ group!(Windows => &'a BitSlice<T, O> {
 			self.slice = Default::default();
 			return None;
 		}
-		unsafe {
-			let out = self.slice.get_unchecked(len - self.width ..);
-			self.slice = self.slice.get_unchecked(.. len - 1);
+		
+			let out = unsafe { self.slice.get_unchecked(len - self.width ..) };
+			self.slice = unsafe { self.slice.get_unchecked(.. len - 1) };
 			Some(out)
-		}
+		
 	}
 
 	fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
@@ -602,11 +602,11 @@ group!(Windows => &'a BitSlice<T, O> {
 			self.slice = Default::default();
 			return None;
 		}
-		unsafe {
-			let out = self.slice.get_unchecked(end - self.width .. end);
-			self.slice = self.slice.get_unchecked(.. end - 1);
+		
+			let out = unsafe { self.slice.get_unchecked(end - self.width .. end) };
+			self.slice = unsafe { self.slice.get_unchecked(.. end - 1) };
 			Some(out)
-		}
+		
 	}
 
 	fn len(&self) -> usize {
@@ -655,11 +655,11 @@ group!(Chunks => &'a BitSlice<T, O> {
 		let split = start.checked_add(self.width)
 			.map(|mid| cmp::min(mid, len))
 			.unwrap_or(len);
-		unsafe {
-			let (head, rest) = self.slice.split_at_unchecked(split);
+		
+			let (head, rest) = unsafe { self.slice.split_at_unchecked(split) };
 			self.slice = rest;
-			Some(head.get_unchecked(start ..))
-		}
+			Some(unsafe { head.get_unchecked(start ..) })
+		
 	}
 
 	fn next_back(&mut self) -> Option<Self::Item> {
@@ -1579,9 +1579,9 @@ split!(Split => &'a BitSlice<T, O> {
 			.position(|(idx, bit)| (self.pred)(idx, bit))
 		{
 			None => self.finish(),
-			Some(idx) => unsafe {
-				let out = self.slice.get_unchecked(.. idx);
-				self.slice = self.slice.get_unchecked(idx + 1 ..);
+			Some(idx) => {
+				let out = unsafe { self.slice.get_unchecked(.. idx) };
+				self.slice = unsafe { self.slice.get_unchecked(idx + 1 ..) };
 				Some(out)
 			},
 		}
@@ -1598,9 +1598,9 @@ split!(Split => &'a BitSlice<T, O> {
 			.rposition(|(idx, bit)| (self.pred)(idx, bit))
 		{
 			None => self.finish(),
-			Some(idx) => unsafe {
-				let out = self.slice.get_unchecked(idx + 1 ..);
-				self.slice = self.slice.get_unchecked(.. idx);
+			Some(idx) => {
+				let out = unsafe { self.slice.get_unchecked(idx + 1 ..) };
+				self.slice = unsafe { self.slice.get_unchecked(.. idx) };
 				Some(out)
 			},
 		}
@@ -1638,10 +1638,10 @@ split!(SplitMut => &'a mut BitSlice<T::Alias, O> {
 		match idx_opt
 		{
 			None => self.finish(),
-			Some(idx) => unsafe {
+			Some(idx) => {
 				let slice = mem::take(&mut self.slice);
-				let (out, rest) = slice.split_at_unchecked_mut_noalias(idx);
-				self.slice = rest.get_unchecked_mut(1 ..);
+				let (out, rest) = unsafe { slice.split_at_unchecked_mut_noalias(idx) };
+				self.slice = unsafe { rest.get_unchecked_mut(1 ..) };
 				Some(out)
 			},
 		}
@@ -1662,11 +1662,11 @@ split!(SplitMut => &'a mut BitSlice<T::Alias, O> {
 		match idx_opt
 		{
 			None => self.finish(),
-			Some(idx) => unsafe {
+			Some(idx) => {
 				let slice = mem::take(&mut self.slice);
-				let (rest, out) = slice.split_at_unchecked_mut_noalias(idx);
+				let (rest, out) = unsafe { slice.split_at_unchecked_mut_noalias(idx) };
 				self.slice = rest;
-				Some(out.get_unchecked_mut(1 ..))
+				Some(unsafe { out.get_unchecked_mut(1 ..) })
 			},
 		}
 	}

--- a/src/slice/specialization/lsb0.rs
+++ b/src/slice/specialization/lsb0.rs
@@ -43,14 +43,14 @@ where T: BitStore
 	) {
 		let (mut this, mut that) = (self, rhs);
 		while this.len() >= WORD_BITS && that.len() >= WORD_BITS {
-			unsafe {
-				let (l, left) = this.split_at_unchecked_mut_noalias(WORD_BITS);
-				let (r, right) = that.split_at_unchecked(WORD_BITS);
+			
+				let (l, left) = unsafe { this.split_at_unchecked_mut_noalias(WORD_BITS) };
+				let (r, right) = unsafe { that.split_at_unchecked(WORD_BITS) };
 				this = left;
 				that = right;
 				let (a, b) = (l.load_le::<usize>(), r.load_le::<usize>());
 				l.store_le(word_op(a, b));
-			}
+			
 		}
 		//  Note: it might actually be possible to do a partial-word load/store
 		//  to exhaust the shorter bit-slice. Investigate further.

--- a/src/slice/specialization/msb0.rs
+++ b/src/slice/specialization/msb0.rs
@@ -43,14 +43,14 @@ where T: BitStore
 	) {
 		let (mut this, mut that) = (self, rhs);
 		while this.len() >= WORD_BITS && that.len() >= WORD_BITS {
-			unsafe {
-				let (l, left) = this.split_at_unchecked_mut_noalias(WORD_BITS);
-				let (r, right) = that.split_at_unchecked(WORD_BITS);
+			
+				let (l, left) = unsafe { this.split_at_unchecked_mut_noalias(WORD_BITS) };
+				let (r, right) = unsafe { that.split_at_unchecked(WORD_BITS) };
 				this = left;
 				that = right;
 				let (a, b) = (l.load_be::<usize>(), r.load_be::<usize>());
 				l.store_be(word_op(a, b));
-			}
+			
 		}
 		for (l, r) in this
 			.as_mut_bitptr_range()


### PR DESCRIPTION
In these function you use the unsafe keyword for some safe expressions. However, I found that only 3 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the split_at_unchecked_mut_noalias()\split_at_unchecked()\get_unchecked() function(these are unsafe functions)

@myrrlyn
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 