### PR TITLE
Add `#[track_caller]` in more locations

### DIFF
--- a/src/array/ops.rs
+++ b/src/array/ops.rs
@@ -208,6 +208,7 @@ where
 	type Output = <BitSlice<A::Store, O> as Index<Idx>>::Output;
 
 	#[inline]
+	#[track_caller]
 	fn index(&self, index: Idx) -> &Self::Output {
 		&self.as_bitslice()[index]
 	}
@@ -220,6 +221,7 @@ where
 	BitSlice<A::Store, O>: IndexMut<Idx>,
 {
 	#[inline]
+	#[track_caller]
 	fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
 		&mut self.as_mut_bitslice()[index]
 	}

--- a/src/boxed/ops.rs
+++ b/src/boxed/ops.rs
@@ -222,6 +222,7 @@ where
 	type Output = <BitSlice<T, O> as Index<Idx>>::Output;
 
 	#[inline]
+	#[track_caller]
 	fn index(&self, index: Idx) -> &Self::Output {
 		&self.as_bitslice()[index]
 	}
@@ -235,6 +236,7 @@ where
 	BitSlice<T, O>: IndexMut<Idx>,
 {
 	#[inline]
+	#[track_caller]
 	fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
 		&mut self.as_mut_bitslice()[index]
 	}

--- a/src/slice/api.rs
+++ b/src/slice/api.rs
@@ -2589,17 +2589,22 @@ where
 	}
 
 	#[inline]
+	#[track_caller]
 	fn index(self, bits: &'a BitSlice<T, O>) -> Self::Immut {
-		self.get(bits).unwrap_or_else(|| {
-			panic!("index {} out of bounds: {}", self, bits.len())
-		})
+		match self.get(bits) {
+			Some(b) => b,
+			None => panic!("index {} out of bounds: {}", self, bits.len())
+		}
 	}
 
 	#[inline]
+	#[track_caller]
 	fn index_mut(self, bits: &'a mut BitSlice<T, O>) -> Self::Mut {
 		let len = bits.len();
-		self.get_mut(bits)
-			.unwrap_or_else(|| panic!("index {} out of bounds: {}", self, len))
+		match self.get_mut(bits) {
+			Some(b) => b,
+			None => panic!("index {} out of bounds: {}", self, len),
+		}
 	}
 }
 
@@ -2660,9 +2665,10 @@ macro_rules! range_impl {
 			fn index(self, bits: Self::Immut) -> Self::Immut {
 				let r = self.clone();
 				let l = bits.len();
-				self.get(bits).unwrap_or_else(|| {
-					panic!("range {:?} out of bounds: {}", r, l)
-				})
+				match self.get(bits) {
+					Some(b) => b,
+					None => panic!("range {:?} out of bounds: {}", r, l),
+				}
 			}
 
 			#[inline]
@@ -2670,9 +2676,10 @@ macro_rules! range_impl {
 			fn index_mut(self, bits: Self::Mut) -> Self::Mut {
 				let r = self.clone();
 				let l = bits.len();
-				self.get_mut(bits).unwrap_or_else(|| {
-					panic!("range {:?} out of bounds: {}", r, l)
-				})
+				match self.get_mut(bits) {
+					Some(b) => b,
+					None => panic!("range {:?} out of bounds: {}", r, l),
+				}
 			}
 		}
 	};

--- a/src/slice/ops.rs
+++ b/src/slice/ops.rs
@@ -155,6 +155,7 @@ where
 	/// bits[1]; // --------^
 	/// ```
 	#[inline]
+	#[track_caller]
 	fn index(&self, index: usize) -> &Self::Output {
 		match *index.index(self) {
 			true => &true,

--- a/src/vec/ops.rs
+++ b/src/vec/ops.rs
@@ -233,6 +233,7 @@ where
 	type Output = <BitSlice<T, O> as Index<Idx>>::Output;
 
 	#[inline]
+	#[track_caller]
 	fn index(&self, index: Idx) -> &Self::Output {
 		&self.as_bitslice()[index]
 	}
@@ -246,6 +247,7 @@ where
 	BitSlice<T, O>: IndexMut<Idx>,
 {
 	#[inline]
+	#[track_caller]
 	fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
 		&mut self.as_mut_bitslice()[index]
 	}


### PR DESCRIPTION
Adds the `#[track_caller]` attribute to more instances of `index` and `index_mut`. In the cases where the panic occurs in a closure, the closure is removed, as it is not currently possible to decorate closures with the `#[track_caller]` attribute.