### PR TITLE
Fixed example numbering and description

### DIFF
--- a/book/memory-model.md
+++ b/book/memory-model.md
@@ -225,10 +225,13 @@ There are nine example slices here, but they can be reduced into six specific
 categories, and two general ones:
 
 1. empty: row 1
+1. partially-spanning tail, no body: row 2
 1. minor (interior of an element, no edge indices): row 3
-1. partially-spanning head, fully-spanning body: rows 3 and 6
-1. partially-spanning tail, fully-spanning body: rows 2 and 7
-1. major (partial head, partial tail, full body): rows 5 and 8
+1. partially-spanning head, no body: rows 4
+1. major (partial head, partial tail, no body): row 5
+1. partially-spanning head, fully-spanning body: row 6
+1. partially-spanning tail, fully-spanning body: row 7
+1. major (partial head, partial tail, full body): row 8
 1. spanning: row 9
 
 The minor slice (row 3) is irreducible; the rest can all be divided into three


### PR DESCRIPTION
##### Commit details
- `3` no longer appears twice (the second occurrence should have been `4`)
- differentiate between no body and fully-spanning body

##### Optional further changes
Because I also changed the ordering of the list to be the same as the example slices in the diagram above it, it would be possible to omit the `row #` suffix for each item in the list.

Feel free to make this change, if you like (you could also ask me to do so, but that feels like unnecessary overhead).

# Something unrelated: What's with the umlauts?
I noticed there are extra umlauts all over the place. In this particular document there are the following ones for example:
- whatso**ë**ver
- re**ö**rderable
- co**ë**xisting

You appear to deliberately use them on vowels following another vowel, but that is non-standard in English. Additionally, as a native German speaker (who uses certain characters accented with umlauts daily), the `ä`, `ö` and `ü` feel just plain wrong, because those would be pronounced differently than `a`, `o` and `u`. (`ë` and `ï` would fine from _that_ point of view, though still unexpected).

What's your point of view on this? I _could_ replace them if you wanted. I assume the relevant directories would be `book/` and `doc/`.