### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,9 +14,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup mdbook
         uses: peaceiris/actions-mdbook@v1


### PR DESCRIPTION
Currently, the CI workflow to deploy the gh-pages fails. See e. g. https://github.com/ferrilab/bitvec/actions/runs/3500371119/jobs/5862965920 for an example. It fails with the error message:

```
mdbook: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by mdbook)
mdbook: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by mdbook)
Error: Process completed with exit code 1.
```

The current version of the action [`peaceiris/actions-mdbook`](https://github.com/peaceiris/actions-mdbook) only supports Ubuntu 22.04 or 20.04, but not Ubuntu 18.04 anymore. So an update of the runner from Ubuntu 18.04 to Ubuntu 22.04 is probably the best way to fix this.

Furthermore, the action `actions/checkout` is updated to get rid of a deprecation warning related to an old Node.js version.