### PR TITLE
add track_caller in more places

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -111,6 +111,7 @@ where
 	/// assert_eq!(addr, bb.as_raw_slice().as_ptr());
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn from_boxed_slice(boxed: Box<[T]>) -> Self {
 		Self::try_from_boxed_slice(boxed)
 			.expect("slice was too long to be converted into a `BitBox`")

--- a/src/field.rs
+++ b/src/field.rs
@@ -521,6 +521,7 @@ where
 
 This panics if `len` is not in `1 ..= U::BITS`.
 **/
+#[track_caller]
 fn check<I>(action: &'static str, len: usize)
 where I: Integral {
 	assert!(

--- a/src/index.rs
+++ b/src/index.rs
@@ -355,6 +355,7 @@ where R: BitRegister
 	/// ## Panics
 	///
 	/// Debug builds panic when `err` is a valid index for `R`.
+	#[track_caller]
 	pub(crate) fn new(err: u8) -> Self {
 		debug_assert!(
 			err >= bits_of::<R>() as u8,

--- a/src/ptr/single.rs
+++ b/src/ptr/single.rs
@@ -921,6 +921,7 @@ where
 	/// [`.add()`]: Self::add
 	/// [`.wrapping_add()`]: Self::wrapping_add
 	#[inline]
+	#[track_caller]
 	pub fn align_offset(self, align: usize) -> usize {
 		let width = mem::bits_of::<T::Mem>();
 		match (

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -243,6 +243,7 @@ where
 	/// [`BitView`]: crate::view::BitView
 	/// [`.view_bits::<O>()`]: crate::view::BitView::view_bits
 	#[inline]
+	#[track_caller]
 	pub fn from_slice(slice: &[T]) -> &Self {
 		Self::try_from_slice(slice).unwrap()
 	}
@@ -331,6 +332,7 @@ where
 	/// [`BitView`]: crate::view::BitView
 	/// [`.view_bits_mut::<O>()`]: crate::view::BitView::view_bits_mut
 	#[inline]
+	#[track_caller]
 	pub fn from_slice_mut(slice: &mut [T]) -> &mut Self {
 		Self::try_from_slice_mut(slice).unwrap()
 	}
@@ -549,6 +551,7 @@ where
 	///
 	/// [`.copy_from_bitslice()`]: Self::copy_from_bitslice
 	#[inline]
+	#[track_caller]
 	pub fn clone_from_bitslice<T2, O2>(&mut self, src: &BitSlice<T2, O2>)
 	where
 		T2: BitStore,
@@ -594,6 +597,7 @@ where
 	/// use bitvec::prelude::*;
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn copy_from_bitslice(&mut self, src: &Self) {
 		assert_eq!(
 			self.len(),
@@ -688,6 +692,7 @@ where
 	/// # }
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn swap_with_bitslice<T2, O2>(&mut self, other: &mut BitSlice<T2, O2>)
 	where
 		T2: BitStore,
@@ -750,6 +755,7 @@ where
 	/// assert_eq!(bits, bits![1, 0]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn set(&mut self, index: usize, value: bool) {
 		self.replace(index, value);
 	}
@@ -804,6 +810,7 @@ where
 	/// assert!(bits[0]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn replace(&mut self, index: usize, value: bool) -> bool {
 		self.assert_in_bounds(index, 0 .. self.len());
 		unsafe { self.replace_unchecked(index, value) }
@@ -1471,6 +1478,7 @@ where
 	/// assert_eq!(bits, bits![0; 2]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn shift_start(&mut self, by: usize) {
 		if by == 0 {
 			return;
@@ -1537,6 +1545,7 @@ where
 	/// assert_eq!(bits, bits![0; 2]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn shift_end(&mut self, by: usize) {
 		if by == 0 {
 			return;
@@ -1595,6 +1604,7 @@ where
 	/// ## Panics
 	///
 	/// This panics if `bounds` is outside `index`.
+	#[track_caller]
 	pub(crate) fn assert_in_bounds<R>(&self, index: usize, bounds: R)
 	where R: RangeExt<usize> {
 		let bounds = bounds.normalize(0, self.len());
@@ -1687,6 +1697,7 @@ where
 	///
 	/// [`.set()`]: Self::set
 	#[inline]
+	#[track_caller]
 	pub fn set_aliased(&self, index: usize, value: bool) {
 		self.assert_in_bounds(index, 0 .. self.len());
 		unsafe {

--- a/src/slice/api.rs
+++ b/src/slice/api.rs
@@ -596,6 +596,7 @@ where
 	/// assert_eq!(bits, bits![1, 0]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn swap(&mut self, a: usize, b: usize) {
 		let bounds = 0 .. self.len();
 		self.assert_in_bounds(a, bounds.clone());
@@ -735,6 +736,7 @@ where
 	/// assert!(iter.next().is_none());
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn windows(&self, size: usize) -> Windows<T, O> {
 		Windows::new(self, size)
 	}
@@ -780,6 +782,7 @@ where
 	/// [`.chunks_mut()`]: Self::chunks_mut
 	/// [`.rchunks()`]: Self::rchunks
 	#[inline]
+	#[track_caller]
 	pub fn chunks(&self, chunk_size: usize) -> Chunks<T, O> {
 		Chunks::new(self, chunk_size)
 	}
@@ -831,6 +834,7 @@ where
 	/// [`.rchunks_mut()`]: Self::rchunks_mut
 	/// [`.remove_alias()`]: crate::slice::ChunksMut::remove_alias
 	#[inline]
+	#[track_caller]
 	pub fn chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<T, O> {
 		ChunksMut::new(self, chunk_size)
 	}
@@ -877,6 +881,7 @@ where
 	/// [`.rchunks_exact()`]: Self::rchunks_exact
 	/// [`.remainder()`]: crate::slice::ChunksExact::remainder
 	#[inline]
+	#[track_caller]
 	pub fn chunks_exact(&self, chunk_size: usize) -> ChunksExact<T, O> {
 		ChunksExact::new(self, chunk_size)
 	}
@@ -935,6 +940,7 @@ where
 	/// [`.rchunks_exact_mut()`]: Self::rchunks_exact_mut
 	/// [`.remove_alias()`]: crate::slice::ChunksExactMut::remove_alias
 	#[inline]
+	#[track_caller]
 	pub fn chunks_exact_mut(
 		&mut self,
 		chunk_size: usize,
@@ -984,6 +990,7 @@ where
 	/// [`.rchunks_exact()`]: Self::rchunks_exact
 	/// [`.rchunks_mut()`]: Self::rchunks_mut
 	#[inline]
+	#[track_caller]
 	pub fn rchunks(&self, chunk_size: usize) -> RChunks<T, O> {
 		RChunks::new(self, chunk_size)
 	}
@@ -1082,6 +1089,7 @@ where
 	/// [`.rchunks_exact_mut()`]: Self::rchunks_exact_mut
 	/// [`.remainder()`]: crate::slice::RChunksExact::remainder
 	#[inline]
+	#[track_caller]
 	pub fn rchunks_exact(&self, chunk_size: usize) -> RChunksExact<T, O> {
 		RChunksExact::new(self, chunk_size)
 	}
@@ -1137,6 +1145,7 @@ where
 	/// [`.rchunks_mut()`]: Self::rchunks_mut
 	/// [`.remove_alias()`]: crate::slice::RChunksExactMut::remove_alias
 	#[inline]
+	#[track_caller]
 	pub fn rchunks_exact_mut(
 		&mut self,
 		chunk_size: usize,
@@ -1185,6 +1194,7 @@ where
 	/// assert_eq!(b, bits![1; 3]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn split_at(&self, mid: usize) -> (&Self, &Self) {
 		self.assert_in_bounds(mid, 0 ..= self.len());
 		unsafe { self.split_at_unchecked(mid) }
@@ -1241,6 +1251,7 @@ where
 	/// assert_eq!(bits, bits![0, 1, 1, 1, 0, 1]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn split_at_mut(
 		&mut self,
 		mid: usize,
@@ -2225,6 +2236,7 @@ where
 	/// //                                             ^  ^  ^  ^
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn copy_within<R>(&mut self, src: R, dest: usize)
 	where R: RangeExt<usize> {
 		let len = self.len();
@@ -2395,6 +2407,7 @@ where
 	/// bits![0, 1].repeat(BitSlice::<usize, Lsb0>::MAX_BITS);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn repeat(&self, n: usize) -> BitVec<T::Unalias, O> {
 		let len = self.len();
 		let total = len.checked_mul(n).expect("capacity overflow");

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -175,6 +175,7 @@ where
 	/// assert_eq!(bv.len(), 32);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn from_slice(slice: &[T]) -> Self {
 		Self::try_from_slice(slice).unwrap()
 	}
@@ -218,6 +219,7 @@ where
 	/// assert_eq!(bv.len(), 32);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn from_vec(vec: Vec<T>) -> Self {
 		Self::try_from_vec(vec)
 			.expect("vector was too long to be converted into a `BitVec`")
@@ -592,6 +594,7 @@ where
 	///
 	/// This panics if `len` is too large to encode into a `BitSpan`.
 	#[inline]
+	#[track_caller]
 	fn assert_len_encodable(len: usize) {
 		assert!(
 			BitSpan::<Const, T, O>::len_encodable(len),
@@ -618,6 +621,7 @@ where
 	/// extended with zero-initialized elements until `self.len() + additional`
 	/// bits have been given initialized memory.
 	#[inline]
+	#[track_caller]
 	fn do_reservation(
 		&mut self,
 		additional: usize,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -76,6 +76,10 @@ where
 
 	/// Creates a new bit-vector by repeating a bit for the desired length.
 	///
+	/// ## Panics
+	///
+	/// This method panics if `len` exceeds the `BitVec` capacity.
+	///
 	/// ## Examples
 	///
 	/// ```rust
@@ -85,6 +89,7 @@ where
 	/// let ones = BitVec::<u16, Lsb0>::repeat(true, 50);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn repeat(bit: bool, len: usize) -> Self {
 		let mut out = Self::with_capacity(len);
 		unsafe {

--- a/src/vec/api.rs
+++ b/src/vec/api.rs
@@ -100,6 +100,7 @@ where
 	///
 	/// [`BitSlice::MAX_BITS`]: crate::slice::BitSlice::MAX_BITS
 	#[inline]
+	#[track_caller]
 	pub fn with_capacity(capacity: usize) -> Self {
 		Self::assert_len_encodable(capacity);
 		let mut vec = capacity
@@ -243,6 +244,7 @@ where
 	/// assert!(bv.capacity() >= 800);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn reserve(&mut self, additional: usize) {
 		Self::assert_len_encodable(self.len() + additional);
 		self.do_reservation(additional, Vec::<T>::reserve);
@@ -281,6 +283,7 @@ where
 	///
 	/// [`.reserve()`]: Self::reserve
 	#[inline]
+	#[track_caller]
 	pub fn reserve_exact(&mut self, additional: usize) {
 		self.do_reservation(additional, Vec::<T>::reserve_exact);
 	}
@@ -442,6 +445,7 @@ where
 	/// [`.push()`]: Self::push
 	/// [`.capacity()`]: Self::capacity
 	#[inline]
+	#[track_caller]
 	pub unsafe fn set_len(&mut self, new_len: usize) {
 		let capa = self.capacity();
 		assert!(
@@ -476,6 +480,7 @@ where
 	/// assert_eq!(bv, bits![0, 1, 1, 0]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn swap_remove(&mut self, index: usize) -> bool {
 		self.assert_in_bounds(index, 0 .. self.len());
 		let last = self.len() - 1;
@@ -500,6 +505,7 @@ where
 	///
 	/// This panics if `index` is out of bounds (including `self.len()`).
 	#[inline]
+	#[track_caller]
 	pub fn insert(&mut self, index: usize, value: bool) {
 		self.assert_in_bounds(index, 0 ..= self.len());
 		self.push(value);
@@ -519,6 +525,7 @@ where
 	///
 	/// This panics if `index` is out of bounds (excluding `self.len()`).
 	#[inline]
+	#[track_caller]
 	pub fn remove(&mut self, index: usize) -> bool {
 		self.assert_in_bounds(index, 0 .. self.len());
 		let last = self.len() - 1;
@@ -614,6 +621,7 @@ where
 	/// assert_eq!(bv.as_bitslice(), bits![0, 0, 1]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn push(&mut self, value: bool) {
 		let len = self.len();
 		let new_len = len + 1;
@@ -693,6 +701,7 @@ where
 	/// assert!(bv2.is_empty());
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn append<T2, O2>(&mut self, other: &mut BitVec<T2, O2>)
 	where
 		T2: BitStore,
@@ -733,6 +742,7 @@ where
 	/// assert!(bv.is_empty());
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn drain<R>(&mut self, range: R) -> Drain<T, O>
 	where R: RangeBounds<usize> {
 		Drain::new(self, range)
@@ -961,6 +971,7 @@ where
 	/// assert_eq!(bv, bits![0, 1, 0, 0, 1, 1, 0, 0]);
 	/// ```
 	#[inline]
+	#[track_caller]
 	pub fn extend_from_within<R>(&mut self, src: R)
 	where R: RangeExt<usize> {
 		let old_len = self.len();
@@ -1017,6 +1028,7 @@ where
 	///
 	/// [`self.drain()`]: Self::drain
 	#[inline]
+	#[track_caller]
 	pub fn splice<R, I>(
 		&mut self,
 		range: R,


### PR DESCRIPTION
Adds the `#[track_caller]` attribute to all functions with `## Panics` section in their documentation. I'd assume there's a number of other places to add this, but it should add a reasonable amount more coverage.