### PR TITLE
Fix ChunksExactMut nth(). Fixes #231.

### DIFF
--- a/src/slice/iter.rs
+++ b/src/slice/iter.rs
@@ -1028,7 +1028,7 @@ group!(ChunksExactMut => &'a mut BitSlice<T::Alias, O> {
 	fn nth(&mut self, n: usize) -> Option<Self::Item> {
 		let slice = mem::take(&mut self.slice);
 		let (start, ovf) = n.overflowing_mul(self.width);
-		if start + self.width >= slice.len() || ovf {
+		if start >= slice.len() || ovf {
 			return None;
 		}
 		let (out, rest) = unsafe {

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -271,3 +271,24 @@ fn cooking() {
 		);
 	}
 }
+
+#[test]
+fn chunks_iters_nth() {
+	let mut data = [192u8; 1];
+	let data = data.view_bits_mut::<Lsb0>();
+
+	let chunk_size = 2usize;
+	let expected = bits![1, 1];
+
+	let mut chunks_iter = data.chunks(chunk_size);
+	assert_eq!(chunks_iter.nth(3).unwrap(), expected);
+
+	let mut chunks_exact_iter = data.chunks_exact(chunk_size);
+	assert_eq!(chunks_exact_iter.nth(3).unwrap(), expected);
+
+	let mut chunks_mut_iter = data.chunks_mut(chunk_size);
+	assert_eq!(chunks_mut_iter.nth(3).unwrap(), expected);
+
+	let mut chunks_exact_mut_iter = data.chunks_exact_mut(chunk_size);
+	assert_eq!(chunks_exact_mut_iter.nth(3).unwrap(), expected);
+}

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -274,21 +274,16 @@ fn cooking() {
 
 #[test]
 fn chunks_iters_nth() {
+	// 2^6 + 2^7 = 192
+	// [0, 0, 0, 0, 0, 0, 1, 1]
 	let mut data = [192u8; 1];
 	let data = data.view_bits_mut::<Lsb0>();
 
 	let chunk_size = 2usize;
 	let expected = bits![1, 1];
 
-	let mut chunks_iter = data.chunks(chunk_size);
-	assert_eq!(chunks_iter.nth(3).unwrap(), expected);
-
-	let mut chunks_exact_iter = data.chunks_exact(chunk_size);
-	assert_eq!(chunks_exact_iter.nth(3).unwrap(), expected);
-
-	let mut chunks_mut_iter = data.chunks_mut(chunk_size);
-	assert_eq!(chunks_mut_iter.nth(3).unwrap(), expected);
-
-	let mut chunks_exact_mut_iter = data.chunks_exact_mut(chunk_size);
-	assert_eq!(chunks_exact_mut_iter.nth(3).unwrap(), expected);
+	assert_eq!(data.chunks(chunk_size).nth(3).unwrap(), expected);
+	assert_eq!(data.chunks_exact(chunk_size).nth(3).unwrap(), expected);
+	assert_eq!(data.chunks_mut(chunk_size).nth(3).unwrap(), expected);
+	assert_eq!(data.chunks_exact_mut(chunk_size).nth(3).unwrap(), expected);
 }


### PR DESCRIPTION
It looks like every other `nth()` function has the same logic for the if-statement.