### PR TITLE
Support `copy_within` on empty ranges

### DIFF
--- a/src/slice/api.rs
+++ b/src/slice/api.rs
@@ -2229,6 +2229,12 @@ where
 	where R: RangeExt<usize> {
 		let len = self.len();
 		let src = src.normalize(0, len);
+		// prevent the asserts below from failing for empty ranges
+		if src.start == src.end {
+			assert!(src.start <= len, "range start index {} is out of bounds for bit-slice of length {}", src.start, len);
+			assert!(dest <= len, "index {} is out of bounds for bit-slice of length {}", dest, len);
+			return;
+		}
 		self.assert_in_bounds(src.start, 0 .. len);
 		self.assert_in_bounds(src.end, 0 ..= len);
 		self.assert_in_bounds(dest, 0 .. len);

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -75,6 +75,31 @@ fn copying() {
 	}
 }
 
+// regression tests for #236
+#[test]
+fn copy_within_supports_empty_ranges() {
+	let empty = bits![mut u8, Lsb0; 0; 0];
+	empty.copy_within(0..0, 0);
+	assert_eq!(empty, bits![]);
+
+	let non_empty = bits![mut u8, Lsb0; 0; 3];
+	non_empty.copy_within(2..2, 0);
+	assert_eq!(non_empty, bits![0, 0, 0]);
+}
+#[test]
+#[should_panic]
+fn copy_within_panics_if_empty_range_exceeds_bounds() {
+	let empty_slice = bits![mut u8, Lsb0; 0; 0];
+	empty_slice.copy_within(2..2, 0);
+}
+#[test]
+#[should_panic]
+fn copy_within_panics_if_dest_for_empty_range_exceeds_bounds() {
+	let empty_slice = bits![mut u8, Lsb0; 0; 0];
+	empty_slice.copy_within(0..0, 1);
+}
+
+
 #[test]
 fn writing() {
 	let bits = bits![mut 0; 2];


### PR DESCRIPTION
resolves #236 