### PR TITLE
Implement Clone::clone_from for BitVec

### DIFF
--- a/src/vec/tests/api.rs
+++ b/src/vec/tests/api.rs
@@ -67,4 +67,12 @@ fn misc() {
 	let mut bv = bitvec![0, 0, 1, 1, 0, 0];
 	bv.extend_from_within(2 .. 4);
 	assert_eq!(bv, bits![0, 0, 1, 1, 0, 0, 1, 1]);
+
+	let mut bv = bitvec![0, 0, 1, 1];
+	let bv2 = bitvec![1, 1, 0, 0];
+	bv.clone_from(&bv2);
+	assert_eq!(bv, bv2);
+	let bv3 = bitvec![1, 0];
+	bv.clone_from(&bv3);
+	assert_eq!(bv, bv3);
 }

--- a/src/vec/traits.rs
+++ b/src/vec/traits.rs
@@ -71,6 +71,15 @@ where
 	fn clone(&self) -> Self {
 		Self::from_bitslice(self.as_bitslice())
 	}
+
+	#[inline]
+	fn clone_from(&mut self, other: &Self) {
+		if self.len() == other.len() {
+			self.copy_from_bitslice(other.as_bitslice());
+		} else {
+			*self = other.clone();
+		}
+	}
 }
 
 impl<T, O> Eq for BitVec<T, O>


### PR DESCRIPTION
The default implementation of `clone_from` is just `*self = other.clone()`, which involves an unnecessary allocation if `self.len() == other.len()`. This PR provides a `Clone::clone_from` implementation that calls `copy_from_bitslice` when applicable.