### PR TITLE
Extend from within fix

### DIFF
--- a/src/vec/api.rs
+++ b/src/vec/api.rs
@@ -965,7 +965,7 @@ where
 	where R: RangeExt<usize> {
 		let old_len = self.len();
 		let src = src.normalize(0, old_len);
-		self.assert_in_bounds(src.end, 0 .. old_len);
+		self.assert_in_bounds(src.end, 0 ..=old_len);
 		self.resize(old_len + src.len(), false);
 		unsafe {
 			self.copy_within_unchecked(src, old_len);


### PR DESCRIPTION
Changed the `assert_within_bounds` in the `extend_from_within` function to allow ranges that include the last element of the vector.

Currently when calling ranges that include the the last element of the bit vector the code panics, for example: 
 ```rust
let mut b = bitvec![0; 2];
b.extend_from_within(..);
```
Yields: 
```
thread 'main' panicked at 'index 2 out of range: Excluded(2)
```

Editing the range in the assert will not panic on such ranges.