### PR TITLE
Fix documentation of bounds on argument `by` for `BitArray::shift_end` and `shift_start`

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,10 +2,7 @@
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use core::{
-	marker::PhantomData,
-	ops::RangeBounds,
-};
+use core::{marker::PhantomData, ops::RangeBounds};
 
 use funty::Integral;
 use tap::Pipe;
@@ -13,33 +10,17 @@ use tap::Pipe;
 use tap::Tap;
 use wyz::{
 	bidi::BidiIterator,
-	comu::{
-		Const,
-		Mut,
-	},
+	comu::{Const, Mut},
 	range::RangeExt,
 };
 
 #[cfg(feature = "alloc")]
 use crate::vec::BitVec;
 use crate::{
-	domain::{
-		BitDomain,
-		Domain,
-	},
+	domain::{BitDomain, Domain},
 	mem,
-	order::{
-		BitOrder,
-		Lsb0,
-		Msb0,
-	},
-	ptr::{
-		self as bv_ptr,
-		BitPtr,
-		BitPtrRange,
-		BitSpan,
-		BitSpanError,
-	},
+	order::{BitOrder, Lsb0, Msb0},
+	ptr::{self as bv_ptr, BitPtr, BitPtrRange, BitSpan, BitSpanError},
 	store::BitStore,
 };
 
@@ -50,10 +31,7 @@ mod specialization;
 mod tests;
 mod traits;
 
-pub use self::{
-	api::*,
-	iter::*,
-};
+pub use self::{api::*, iter::*};
 
 #[repr(transparent)]
 #[doc = include_str!("../doc/slice/BitSlice.md")]
@@ -289,8 +267,7 @@ where
 			elts.saturating_mul(mem::bits_of::<T::Mem>())
 				.pipe(BitSpanError::TooLong)
 				.pipe(Err)
-		}
-		else {
+		} else {
 			Ok(unsafe { Self::from_slice_unchecked(slice) })
 		}
 	}
@@ -378,8 +355,7 @@ where
 			elts.saturating_mul(mem::bits_of::<T::Mem>())
 				.pipe(BitSpanError::TooLong)
 				.pipe(Err)
-		}
-		else {
+		} else {
 			Ok(unsafe { Self::from_slice_unchecked_mut(slice) })
 		}
 	}
@@ -607,7 +583,7 @@ where
 			match (self.domain_mut(), src.domain()) {
 				(Domain::Enclave(mut to), Domain::Enclave(from)) => {
 					to.store_value(from.load_value());
-				},
+				}
 				(
 					Domain::Region {
 						head: to_head,
@@ -629,7 +605,7 @@ where
 					if let (Some(mut to), Some(from)) = (to_tail, from_tail) {
 						to.store_value(from.load_value());
 					}
-				},
+				}
 				_ => unreachable!(
 					"bit-slices with equal type parameters, lengths, and heads \
 					 will always have equal domains"
@@ -805,7 +781,7 @@ where
 	/// ```
 	#[inline]
 	pub fn replace(&mut self, index: usize, value: bool) -> bool {
-		self.assert_in_bounds(index, 0 .. self.len());
+		self.assert_in_bounds(index, 0..self.len());
 		unsafe { self.replace_unchecked(index, value) }
 	}
 
@@ -948,7 +924,9 @@ where
 	/// ```
 	#[inline]
 	pub unsafe fn copy_within_unchecked<R>(&mut self, src: R, dest: usize)
-	where R: RangeExt<usize> {
+	where
+		R: RangeExt<usize>,
+	{
 		if let Some(this) = self.coerce_mut::<T, Lsb0>() {
 			return this.sp_copy_within_unchecked(src, dest);
 		}
@@ -958,7 +936,7 @@ where
 		let source = src.normalize(0, self.len());
 		let source_len = source.len();
 		let rev = source.contains(&dest);
-		let dest = dest .. dest + source_len;
+		let dest = dest..dest + source_len;
 		for (from, to) in self
 			.get_unchecked(source)
 			.as_bitptr_range()
@@ -1070,7 +1048,7 @@ where
 						.map(|elem| elem.count_ones() as usize)
 						.sum::<usize>() + tail
 					.map_or(0, |elem| elem.load_value().count_ones() as usize)
-			},
+			}
 		}
 	}
 
@@ -1104,7 +1082,7 @@ where
 					(elem.load_value() | !elem.mask().into_inner()).count_zeros()
 						as usize
 				})
-			},
+			}
 		}
 	}
 
@@ -1453,7 +1431,7 @@ where
 	///
 	/// ## Panics
 	///
-	/// This panics if `by` is not less than `self.len()`.
+	/// This panics if `by` is not less than or equal to `self.len()`.
 	///
 	/// ## Examples
 	///
@@ -1482,14 +1460,14 @@ where
 		}
 		assert!(
 			by <= len,
-			"shift must be less than the length of the bit-slice: {} >= {}",
+			"shift must be less than or equal to the length of the bit-slice: {} > {}",
 			by,
 			len,
 		);
 
 		unsafe {
-			self.copy_within_unchecked(by .., 0);
-			self.get_unchecked_mut(len - by ..).fill(false);
+			self.copy_within_unchecked(by.., 0);
+			self.get_unchecked_mut(len - by..).fill(false);
 		}
 	}
 
@@ -1519,7 +1497,7 @@ where
 	///
 	/// ## Panics
 	///
-	/// This panics if `by` is not less than `self.len()`.
+	/// This panics if `by` is not less than or equal to `self.len()`.
 	///
 	/// ## Examples
 	///
@@ -1548,14 +1526,14 @@ where
 		}
 		assert!(
 			by <= len,
-			"shift must be less than the length of the bit-slice: {} >= {}",
+			"shift must be less than or equal to the length of the bit-slice: {} > {}",
 			by,
 			len,
 		);
 
 		unsafe {
-			self.copy_within_unchecked(.. len - by, by);
-			self.get_unchecked_mut(.. by).fill(false);
+			self.copy_within_unchecked(..len - by, by);
+			self.get_unchecked_mut(..by).fill(false);
 		}
 	}
 
@@ -1596,7 +1574,9 @@ where
 	///
 	/// This panics if `bounds` is outside `index`.
 	pub(crate) fn assert_in_bounds<R>(&self, index: usize, bounds: R)
-	where R: RangeExt<usize> {
+	where
+		R: RangeExt<usize>,
+	{
 		let bounds = bounds.normalize(0, self.len());
 		assert!(
 			bounds.contains(&index),
@@ -1688,7 +1668,7 @@ where
 	/// [`.set()`]: Self::set
 	#[inline]
 	pub fn set_aliased(&self, index: usize, value: bool) {
-		self.assert_in_bounds(index, 0 .. self.len());
+		self.assert_in_bounds(index, 0..self.len());
 		unsafe {
 			self.set_aliased_unchecked(index, value);
 		}


### PR DESCRIPTION
Fixes #250

I changed the assert message, but it might make more sense to change the assertion itself to `by < len` instead of `by <= len`, since we only run the assertion if `by` is not equal to `len`.

I am pretty certain the documentation change is correct.