### PR TITLE
Fix MIRI under tree borrows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 	not(debug_assertions),
 	deny(missing_docs, clippy::missing_docs_in_private_items)
 )]
+#![cfg_attr(miri, feature(strict_provenance))]
 #![deny(unconditional_recursion)]
 #![allow(
 	clippy::declare_interior_mutable_const,

--- a/src/ptr/tests.rs
+++ b/src/ptr/tests.rs
@@ -23,13 +23,14 @@ fn free_functions() {
 
 	let one = BitPtr::<Mut, u8, Lsb0>::from_slice_mut(&mut a[..]);
 	let two = one.wrapping_add(8);
-	let three = BitPtr::<Mut, u16, Msb0>::from_mut(&mut b);
-	let four = three.wrapping_add(8);
 
 	unsafe {
 		bv_ptr::copy(two.to_const(), one, 8);
 	}
 	assert_eq!(a[0], !0);
+
+	let one = BitPtr::<Mut, u8, Lsb0>::from_slice_mut(&mut a[..]);
+	let three = BitPtr::<Mut, u16, Msb0>::from_mut(&mut b);
 	unsafe {
 		bv_ptr::copy(three.to_const(), one, 8);
 	}
@@ -43,6 +44,8 @@ fn free_functions() {
 	assert_eq!(a[1], 0);
 	assert_eq!(b, !0);
 
+	let three = BitPtr::<Mut, u16, Msb0>::from_mut(&mut b);
+	let four = three.wrapping_add(8);
 	unsafe {
 		bv_ptr::write_bits(four, false, 8);
 	}

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::{
+	cell::UnsafeCell,
 	marker::PhantomData,
 	ops::RangeBounds,
 };
@@ -82,7 +83,7 @@ where
 	///
 	/// See `ptr::span` for more information on the encoding scheme used in
 	/// references to `BitSlice`.
-	_mem: [()],
+	_mem: [UnsafeCell<()>],
 }
 
 /// Constructors.

--- a/src/slice/traits.rs
+++ b/src/slice/traits.rs
@@ -20,6 +20,7 @@ use core::{
 		Hash,
 		Hasher,
 	},
+	panic::RefUnwindSafe,
 	str,
 };
 
@@ -539,6 +540,13 @@ where
 	where H: Hasher {
 		self.iter().by_vals().for_each(|bit| bit.hash(hasher));
 	}
+}
+
+impl<T, O> RefUnwindSafe for BitSlice<T, O>
+where
+	T: BitStore + RefUnwindSafe,
+	O: BitOrder,
+{
 }
 
 #[doc = include_str!("../../doc/slice/threadsafe.md")]


### PR DESCRIPTION
This change consists of four modifications to fix the test suite when run under miri with `MIRIFLAGS="-Zmiri-disable-stacked-borrows -Zmiri-tree-borrows"`:

1. `BitSlice` now contains a trailing slice of `[UnsafeCell<()>]` rather than `[()]`. This corrects the pointer aliasing semantics for `BitSlice` so that the self reference does not assert shared or mutable aliasing.
2. Locations which casted `usize`s back to pointers have been switched to use the unstable `ptr::map_addr` function when testing through miri. This function preserves the provenance of the pointer across bit manipulations. This fixes some warnings.
3. A manual impl for `RefUnwindSafe` is now provided for `BitSlice`. I didn't think too hard about this but I'm pretty sure it's right.
4. Some `BitPtr` tests have been fixed up to re-acquire pointers after mutating operations. This re-asserts mutable access to the underlying memory with the correct semantics for tree borrows.