### PR TITLE
Update msrv to 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ keywords = [
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ferrilab/bitvec"
-rust-version = "1.56"
+rust-version = "1.63"
 
 [features]
 alloc = [


### PR DESCRIPTION
The tests depend on criterion, which no longer supports rust 1.56.

Fixes #267