### PR TITLE
Fix format of shift_end docstring

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1504,9 +1504,10 @@ where
 	/// Shifts the contents of a bit-slice “right” (away from the zero-index),
 	/// clearing the “left” bits to `0`.
 	///
-	/// This is a strictly-worse analogue to taking `bits = &bits[.. bits.len()
-	/// - by]`: it must modify the entire memory region that `bits` governs, and
-	/// destroys contained information. Unless the actual memory layout and
+	/// This is a strictly-worse analogue to taking
+	/// `bits = &bits[.. bits.len() - by]`: it must modify the entire memory
+	/// region that `bits` governs, and destroys contained information.
+	/// Unless the actual memory layout and
 	/// contents of your bit-slice matters to your program, you should
 	/// *probably* prefer to munch your way backward through a bit-slice handle.
 	///


### PR DESCRIPTION
It looked like this: https://docs.rs/bitvec/1.0.1/bitvec/array/struct.BitArray.html#method.shift_right