### PR TITLE
Update radium dependency to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ testing = [
 ]
 
 [dependencies]
-radium = "0.7"
+radium = "1.1.0"
 tap = "1"
 
 [dependencies.funty]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -101,17 +101,15 @@ macro_rules! element {
 			}
 		}
 
-		radium::if_atomic!( if atomic($size) {
-			use core::sync::atomic::$atom;
-			impl BitElement<$atom> {
-				/// Creates a new element wrapper from a raw integer.
-				pub const fn new(elem: $bare) -> Self {
-					Self {
-						elem: <$atom>::new(elem),
-					}
+		use core::sync::atomic::$atom;
+		impl BitElement<$atom> where $bare: radium::marker::Atomic {
+			/// Creates a new element wrapper from a raw integer.
+			pub const fn new(elem: $bare) -> Self {
+				Self {
+					elem: <$atom>::new(elem),
 				}
 			}
-		});
+		}
 	)+ };
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -199,36 +199,34 @@ store!(usize => BitSafeUsize);
 /// Generates `BitStore` implementations for atomic types.
 macro_rules! atomic {
 	($($size:tt, $base:ty => $atom:ident);+ $(;)?) => { $(
-		radium::if_atomic!(if atomic($size) {
-			use core::sync::atomic::$atom;
+		use core::sync::atomic::$atom;
 
-			impl BitStore for $atom {
-				type Mem = $base;
-				type Access = Self;
-				type Alias = Self;
-				type Unalias = Self;
+		impl BitStore for $atom where $base: radium::marker::Atomic {
+			type Mem = $base;
+			type Access = Self;
+			type Alias = Self;
+			type Unalias = Self;
 
-				const ZERO: Self = <Self>::new(0);
+			const ZERO: Self = <Self>::new(0);
 
-				#[inline]
-				fn new(value: Self::Mem) -> Self { <Self>::new(value) }
+			#[inline]
+			fn new(value: Self::Mem) -> Self { <Self>::new(value) }
 
-				#[inline]
-				fn load_value(&self) -> Self::Mem {
-					self.load(core::sync::atomic::Ordering::Relaxed)
-				}
-
-				#[inline]
-				fn store_value(&mut self, value: Self::Mem) {
-					*self = Self::new(value);
-				}
-
-				const ALIGNED_TO_SIZE: [(); 1]
-					= [(); mem::aligned_to_size::<Self>() as usize];
-
-				const ALIAS_WIDTH: [(); 1] = [()];
+			#[inline]
+			fn load_value(&self) -> Self::Mem {
+				self.load(core::sync::atomic::Ordering::Relaxed)
 			}
-		});
+
+			#[inline]
+			fn store_value(&mut self, value: Self::Mem) {
+				*self = Self::new(value);
+			}
+
+			const ALIGNED_TO_SIZE: [(); 1]
+				= [(); mem::aligned_to_size::<Self>() as usize];
+
+			const ALIAS_WIDTH: [(); 1] = [()];
+		}
 	)+ };
 }
 


### PR DESCRIPTION
This pull request updates the radium dependency to version 1.1.0, allowing me to use bitvec on a 32 bit x86 target.